### PR TITLE
Add a custom CORS policy

### DIFF
--- a/backend/API/Controllers/ConfigController.cs
+++ b/backend/API/Controllers/ConfigController.cs
@@ -1,6 +1,7 @@
 ﻿using API.Models;
 using API.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,6 +20,7 @@ public class ConfigController(
     }
 
     [HttpGet]
+    [EnableCors("Public")]
     public async Task<Ok<IEnumerable<LocalKey>>> GetAll()
     {
         var result = await _localKeyService.GetAll();

--- a/backend/API/Program.cs
+++ b/backend/API/Program.cs
@@ -96,9 +96,9 @@ builder.Services
 builder.Services.Configure<AuthenticationSettings>(
     options => builder.Configuration.GetSection("Authentication").Bind(options));
 
-#if DEBUG
 builder.Services.AddCors(options =>
 {
+#if DEBUG
     options.AddPolicy("AllowSpecificOrigin",
         policy =>
         {
@@ -106,8 +106,14 @@ builder.Services.AddCors(options =>
                   .AllowAnyHeader()
                   .AllowAnyMethod();
         });
-});
 #endif
+    options.AddPolicy("Public",
+        policy =>
+        {
+            policy.WithOrigins("https://www.etemadify.com")
+                .WithMethods("GET");
+        });
+});
 
 var app = builder.Build();
 
@@ -122,9 +128,11 @@ else
 {
     app.UseDefaultFiles();
     app.UseStaticFiles();
+    
 }
 
 app.UseHttpsRedirection();
+app.UseCors("Public");
 
 app
     .UseAuthentication()


### PR DESCRIPTION
### What
- It will close #11
- A custom CORS policy has been added to serve possible cross origin api call

### Why
- IOS app is not able to recognize the URL that has been generated